### PR TITLE
Update Scale9Sprite tests.

### DIFF
--- a/tests/ExtensionsTest/S9SpriteTest/S9SpriteTest.js
+++ b/tests/ExtensionsTest/S9SpriteTest/S9SpriteTest.js
@@ -98,7 +98,8 @@ var S9SpriteTestDemo = cc.LayerGradient.extend({
 
 var S9BatchNodeBasic = S9SpriteTestDemo.extend({
 
-    _title:"Test Scale9Sprite creation and rendering",
+    _title:"Scale9Sprite created empty and updated from SpriteBatchNode",
+    _subtitle:"updateWithBatchNode(); capInsets=full size",
 
     ctor:function() {
         this._super();
@@ -127,11 +128,12 @@ var S9BatchNodeBasic = S9SpriteTestDemo.extend({
     }
 });
 
-// S9BatchNodeBasicSpriteSheet
+// S9FrameNameSpriteSheet
 
-var S9BatchNodeBasicSpriteSheet = S9SpriteTestDemo.extend({
+var S9FrameNameSpriteSheet = S9SpriteTestDemo.extend({
 
-    _title:"Test Scale9Sprite sprite sheet creation and rendering",
+    _title:"Scale9Sprite from sprite sheet",
+    _subtitle:"createWithSpriteFrameName(); default cap insets",
 
     ctor:function() {
         this._super();
@@ -139,7 +141,7 @@ var S9BatchNodeBasicSpriteSheet = S9SpriteTestDemo.extend({
         var x = winSize.width / 6;
         var y = 0 + (winSize.height / 6);
 
-        cc.log("S9BatchNodeBasicSpriteSheet ...");
+        cc.log("S9FrameNameSpriteSheet ...");
 
         var blocks = cc.Scale9Sprite.createWithSpriteFrameName('blocks9.png');
         cc.log("... created");
@@ -150,15 +152,16 @@ var S9BatchNodeBasicSpriteSheet = S9SpriteTestDemo.extend({
         this.addChild(blocks);
         cc.log("this..addChild");
 
-        cc.log("... S9BatchNodeBasicSpriteSheet done.");
+        cc.log("... S9FrameNameSpriteSheet done.");
     }
 });
 
-// S9BatchNodeBasicSpriteSheetRotated
+// S9FrameNameSpriteSheetRotated
 
-var S9BatchNodeBasicSpriteSheetRotated = S9SpriteTestDemo.extend({
+var S9FrameNameSpriteSheetRotated = S9SpriteTestDemo.extend({
 
-    _title:"Test Scale9Sprite rotated sprite sheet creation and rendering",
+    _title:"Scale9Sprite from sprite sheet (stored rotated)",
+    _subtitle:"createWithSpriteFrameName(); default cap insets",
 
     ctor:function() {
         this._super();
@@ -166,7 +169,7 @@ var S9BatchNodeBasicSpriteSheetRotated = S9SpriteTestDemo.extend({
         var x = winSize.width / 6;
         var y = 0 + (winSize.height / 6);
 
-        cc.log("S9BatchNodeBasicSpriteSheetRotated ...");
+        cc.log("S9FrameNameSpriteSheetRotated ...");
 
         var blocks = cc.Scale9Sprite.createWithSpriteFrameName('blocks9r.png');
         cc.log("... created");
@@ -177,16 +180,16 @@ var S9BatchNodeBasicSpriteSheetRotated = S9SpriteTestDemo.extend({
         this.addChild(blocks);
         cc.log("this..addChild");
 
-
-        cc.log("... S9BatchNodeBasicSpriteSheetRotated done.");
+        cc.log("... S9FrameNameSpriteSheetRotated done.");
     }
 });
 
-// S9BatchNodeScaleNoInsets
+// S9BatchNodeScaledNoInsets
 
-var S9BatchNodeScaleNoInsets = S9SpriteTestDemo.extend({
+var S9BatchNodeScaledNoInsets = S9SpriteTestDemo.extend({
 
-    _title:"Scale9Sprite scaled with no insets",
+    _title:"Scale9Sprite created empty and updated from SpriteBatchNode",
+    _subtitle:"updateWithBatchNode(); capInsets=full size; rendered 4 X width, 2 X height",
 
     ctor:function() {
         this._super();
@@ -194,7 +197,7 @@ var S9BatchNodeScaleNoInsets = S9SpriteTestDemo.extend({
         var x = winSize.width / 6;
         var y = 0 + (winSize.height / 6);
 
-        cc.log("S9BatchNodeScaleNoInsets ...");
+        cc.log("S9BatchNodeScaledNoInsets ...");
 
         // scaled without insets
         var batchNode_scaled = cc.SpriteBatchNode.create("res/Images/blocks9.png");
@@ -214,15 +217,16 @@ var S9BatchNodeScaleNoInsets = S9SpriteTestDemo.extend({
         this.addChild(blocks_scaled);
         cc.log("this..addChild");
 
-        cc.log("... S9BtchNodeScaleNoInsets done.");
+        cc.log("... S9BtchNodeScaledNoInsets done.");
     }
 });
 
-// S9BatchNodeScaleNoInsetsSpriteSheet
+// S9FrameNameSpriteSheetScaledNoInsets
 
-var S9BatchNodeScaleNoInsetsSpriteSheet = S9SpriteTestDemo.extend({
+var S9FrameNameSpriteSheetScaledNoInsets = S9SpriteTestDemo.extend({
 
-    _title:"Scale9Sprite scaled with no insets sprite sheet",
+    _title:"Scale9Sprite from sprite sheet",
+    _subtitle:"createWithSpriteFrameName(); default cap insets; rendered 4 X width, 2 X height",
 
     ctor:function() {
         this._super();
@@ -230,7 +234,7 @@ var S9BatchNodeScaleNoInsetsSpriteSheet = S9SpriteTestDemo.extend({
         var x = winSize.width / 6;
         var y = 0 + (winSize.height / 6);
 
-        cc.log("S9BatchNodeScaleNoInsetsSpriteSheet ...");
+        cc.log("S9FrameNameSpriteSheetScaledNoInsets ...");
 
         var blocks_scaled = cc.Scale9Sprite.createWithSpriteFrameName('blocks9.png');
         cc.log("... created");
@@ -244,15 +248,16 @@ var S9BatchNodeScaleNoInsetsSpriteSheet = S9SpriteTestDemo.extend({
         this.addChild(blocks_scaled);
         cc.log("this..addChild");
 
-        cc.log("... S9BatchNodeScaleNoInsetsSpriteSheet done.");
+        cc.log("... S9FrameNameSpriteSheetScaledNoInsets done.");
     }
 });
 
-// S9BatchNodeScaleNoInsetsSpriteSheetRotated
+// S9FrameNameSpriteSheetRotatedScaledNoInsets
 
-var S9BatchNodeScaleNoInsetsSpriteSheetRotated = S9SpriteTestDemo.extend({
+var S9FrameNameSpriteSheetRotatedScaledNoInsets = S9SpriteTestDemo.extend({
 
-    _title:"Scale9Sprite scaled with no insets rotated sprite sheet",
+    _title:"Scale9Sprite from sprite sheet (stored rotated)",
+    _subtitle:"createWithSpriteFrameName(); default cap insets; rendered 4 X width, 2 X height",
 
     ctor:function() {
         this._super();
@@ -260,7 +265,7 @@ var S9BatchNodeScaleNoInsetsSpriteSheetRotated = S9SpriteTestDemo.extend({
         var x = winSize.width / 6;
         var y = 0 + (winSize.height / 6);
 
-        cc.log("S9BatchNodeScaleNoInsetsSpriteSheetRotated ...");
+        cc.log("S9FrameNameSpriteSheetRotatedScaledNoInsets ...");
 
         var blocks_scaled = cc.Scale9Sprite.createWithSpriteFrameName('blocks9r.png');
         cc.log("... created");
@@ -274,7 +279,7 @@ var S9BatchNodeScaleNoInsetsSpriteSheetRotated = S9SpriteTestDemo.extend({
         this.addChild(blocks_scaled);
         cc.log("this..addChild");
 
-        cc.log("... S9BatchNodeScaleNoInsetsSpriteSheetRotated done.");
+        cc.log("... S9FrameNameSpriteSheetRotatedScaledNoInsets done.");
     }
 });
 
@@ -283,7 +288,8 @@ var S9BatchNodeScaleNoInsetsSpriteSheetRotated = S9SpriteTestDemo.extend({
 
 var S9BatchNodeScaleWithCapInsets = S9SpriteTestDemo.extend({
 
-    _title:"Scale9Sprite scaled with insets",
+    _title:"Scale9Sprite created empty and updated from SpriteBatchNode",
+    _subtitle:"updateWithBatchNode(); capInsets=(32, 32, 32, 32)",
 
     ctor:function() {
         this._super();
@@ -315,11 +321,12 @@ var S9BatchNodeScaleWithCapInsets = S9SpriteTestDemo.extend({
     }
 });
 
-// S9BatchNodeScaleWithCapInsetsSpriteSheet
+// S9FrameNameSpriteSheetInsets
 
-var S9BatchNodeScaleWithCapInsetsSpriteSheet = S9SpriteTestDemo.extend({
+var S9FrameNameSpriteSheetInsets = S9SpriteTestDemo.extend({
 
     _title:"Scale9Sprite scaled with insets sprite sheet",
+    _subtitle:"createWithSpriteFrameName(); cap insets=(32, 32, 32, 32)",
 
     ctor:function() {
         this._super();
@@ -327,7 +334,35 @@ var S9BatchNodeScaleWithCapInsetsSpriteSheet = S9SpriteTestDemo.extend({
         var x = winSize.width / 6;
         var y = 0 + (winSize.height / 6);
 
-        cc.log("S9BatchNodeScaleWithCapInsetsSpriteSheet ...");
+        cc.log("S9FrameNameSpriteSheetInsets ...");
+
+        var blocks_with_insets = cc.Scale9Sprite.createWithSpriteFrameName('blocks9.png', cc.rect(32, 32, 32, 32));
+        cc.log("... created");
+
+        blocks_with_insets.setPosition(cc.p(x, y));
+        cc.log("... setPosition");
+
+        this.addChild(blocks_with_insets);
+        cc.log("this..addChild");
+
+        cc.log("... S9FrameNameSpriteSheetInsets done.");
+    }
+});
+
+// S9FrameNameSpriteSheetInsetsScaled
+
+var S9FrameNameSpriteSheetInsetsScaled = S9SpriteTestDemo.extend({
+
+    _title:"Scale9Sprite scaled with insets sprite sheet",
+    _subtitle:"createWithSpriteFrameName(); default cap insets; rendered scaled 4.5 X width, 2.5 X height",
+
+    ctor:function() {
+        this._super();
+
+        var x = winSize.width / 6;
+        var y = 0 + (winSize.height / 6);
+
+        cc.log("S9FrameNameSpriteSheetInsetsScaled ...");
 
         var blocks_scaled_with_insets = cc.Scale9Sprite.createWithSpriteFrameName('blocks9.png', cc.rect(32, 32, 32, 32));
         cc.log("... created");
@@ -341,15 +376,16 @@ var S9BatchNodeScaleWithCapInsetsSpriteSheet = S9SpriteTestDemo.extend({
         this.addChild(blocks_scaled_with_insets);
         cc.log("this..addChild");
 
-        cc.log("... S9BatchNodeScaleWithCapInsetsSpriteSheet done.");
+        cc.log("... S9FrameNameSpriteSheetInsetsScaled done.");
     }
 });
 
-// S9BatchNodeScaleWithCapInsetsSpriteSheetRotated
+// S9FrameNameSpriteSheetRotatedInsets
 
-var S9BatchNodeScaleWithCapInsetsSpriteSheetRotated = S9SpriteTestDemo.extend({
+var S9FrameNameSpriteSheetRotatedInsets = S9SpriteTestDemo.extend({
 
-    _title:"Scale9Sprite scaled with insets rotated sprite sheet",
+    _title:"Scale9Sprite scaled with insets sprite sheet (stored rotated)",
+    _subtitle:"createWithSpriteFrameName(); cap insets=(32, 32, 32, 32)",
 
     ctor:function() {
         this._super();
@@ -357,9 +393,37 @@ var S9BatchNodeScaleWithCapInsetsSpriteSheetRotated = S9SpriteTestDemo.extend({
         var x = winSize.width / 6;
         var y = 0 + (winSize.height / 6);
 
-        cc.log("S9BatchNodeScaleWithCapInsetsSpriteSheetRotated ...");
+        cc.log("S9FrameNameSpriteSheetRotatedInsets ...");
 
-        var blocks_scaled_with_insets = cc.Scale9Sprite.createWithSpriteFrameName('blocks9r.png', cc.rect(32, 32, 32, 32));
+        var blocks_with_insets = cc.Scale9Sprite.createWithSpriteFrameName('blocks9r.png', cc.rect(32, 32, 32, 32));
+        cc.log("... created");
+
+        blocks_with_insets.setPosition(cc.p(x, y));
+        cc.log("... setPosition");
+
+        this.addChild(blocks_with_insets);
+        cc.log("this..addChild");
+
+        cc.log("... S9FrameNameSpriteSheetRotatedInsets done.");
+    }
+});
+
+// S9FrameNameSpriteSheetRotatedInsetsScaled
+
+var S9FrameNameSpriteSheetRotatedInsetsScaled = S9SpriteTestDemo.extend({
+
+    _title:"Scale9Sprite scaled with insets sprite sheet (stored rotated)",
+    _subtitle:"createWithSpriteFrameName(); default cap insets; rendered scaled 4.5 X width, 2.5 X height",
+
+    ctor:function() {
+        this._super();
+
+        var x = winSize.width / 6;
+        var y = 0 + (winSize.height / 6);
+
+        cc.log("S9FrameNameSpriteSheetRotatedInsetsScaled ...");
+
+        var blocks_scaled_with_insets = cc.Scale9Sprite.createWithSpriteFrameName('blocks9.png', cc.rect(32, 32, 32, 32));
         cc.log("... created");
 
         blocks_scaled_with_insets.setContentSize(cc.size(96 * 4.5, 96 * 2.5));
@@ -371,10 +435,9 @@ var S9BatchNodeScaleWithCapInsetsSpriteSheetRotated = S9SpriteTestDemo.extend({
         this.addChild(blocks_scaled_with_insets);
         cc.log("this..addChild");
 
-        cc.log("... S9BatchNodeScaleWithCapInsetsSpriteSheetRotated done.");
+        cc.log("... S9FrameNameSpriteSheetRotatedInsetsScaled done.");
     }
 });
-
 
 var S9SpriteTestScene = TestScene.extend({
     runThisTest:function () {
@@ -392,14 +455,16 @@ var S9SpriteTestScene = TestScene.extend({
 
 var arrayOfS9SpriteTest = [
     S9BatchNodeBasic,
-    S9BatchNodeBasicSpriteSheet,
-    S9BatchNodeBasicSpriteSheetRotated,
-    S9BatchNodeScaleNoInsets,
-    S9BatchNodeScaleNoInsetsSpriteSheet,
-    S9BatchNodeScaleNoInsetsSpriteSheetRotated,
+    S9FrameNameSpriteSheet,
+    S9FrameNameSpriteSheetRotated,
+    S9BatchNodeScaledNoInsets,
+    S9FrameNameSpriteSheetScaledNoInsets,
+    S9FrameNameSpriteSheetRotatedScaledNoInsets,
     S9BatchNodeScaleWithCapInsets,
-    S9BatchNodeScaleWithCapInsetsSpriteSheet,
-    S9BatchNodeScaleWithCapInsetsSpriteSheetRotated
+    S9FrameNameSpriteSheetInsets,
+    S9FrameNameSpriteSheetInsetsScaled,
+    S9FrameNameSpriteSheetRotatedInsets,
+    S9FrameNameSpriteSheetRotatedInsetsScaled
 ];
 
 var nextS9SpriteTest = function () {


### PR DESCRIPTION
Fix test names. Add descriptive subtitles. Add some tests where Scale9Sprites are rendered without scaling.
