### PR TITLE
Add test for CCSprite using rect

### DIFF
--- a/tests/ExtensionsTest/S9SpriteTest/S9SpriteTest.js
+++ b/tests/ExtensionsTest/S9SpriteTest/S9SpriteTest.js
@@ -331,8 +331,8 @@ var S9FrameNameSpriteSheetInsets = S9SpriteTestDemo.extend({
     ctor:function() {
         this._super();
 
-        var x = winSize.width / 6;
-        var y = 0 + (winSize.height / 6);
+        var x = winSize.width / 2;
+        var y = 0 + (winSize.height / 2);
 
         cc.log("S9FrameNameSpriteSheetInsets ...");
 
@@ -418,8 +418,8 @@ var S9FrameNameSpriteSheetRotatedInsetsScaled = S9SpriteTestDemo.extend({
     ctor:function() {
         this._super();
 
-        var x = winSize.width / 6;
-        var y = 0 + (winSize.height / 6);
+        var x = winSize.width / 2;
+        var y = 0 + (winSize.height / 2);
 
         cc.log("S9FrameNameSpriteSheetRotatedInsetsScaled ...");
 

--- a/tests/ExtensionsTest/S9SpriteTest/S9SpriteTest.js
+++ b/tests/ExtensionsTest/S9SpriteTest/S9SpriteTest.js
@@ -103,8 +103,8 @@ var S9BatchNodeBasic = S9SpriteTestDemo.extend({
     ctor:function() {
         this._super();
 
-        var x = winSize.width / 6;
-        var y = 0 + (winSize.height / 6);
+        var x = winSize.width / 2;
+        var y = 0 + (winSize.height / 2);
 
         cc.log("S9BatchNodeBasic ...");
 
@@ -114,7 +114,7 @@ var S9BatchNodeBasic = S9SpriteTestDemo.extend({
         var blocks = cc.Scale9Sprite.create();
         cc.log("... created");
 
-        blocks.updateWithBatchNode(batchNode, cc.rect(0, 0, 96, 96), false, cc.rect(0, 0, 96, 96));
+        blocks.updateWithBatchNode(batchNode, cc.rect(0, 0, 96, 96), false);
         cc.log("... updateWithBatchNode");
 
         blocks.setPosition(cc.p(x, y));
@@ -136,8 +136,8 @@ var S9BatchNodeBasicSpriteSheet = S9SpriteTestDemo.extend({
     ctor:function() {
         this._super();
 
-        var x = winSize.width / 6;
-        var y = 0 + (winSize.height / 6);
+        var x = winSize.width / 2;
+        var y = 0 + (winSize.height / 2);
 
         cc.log("S9BatchNodeBasicSpriteSheet ...");
 
@@ -163,8 +163,8 @@ var S9BatchNodeBasicSpriteSheetRotated = S9SpriteTestDemo.extend({
     ctor:function() {
         this._super();
 
-        var x = winSize.width / 6;
-        var y = 0 + (winSize.height / 6);
+        var x = winSize.width / 2;
+        var y = 0 + (winSize.height / 2);
 
         cc.log("S9BatchNodeBasicSpriteSheetRotated ...");
 
@@ -191,8 +191,8 @@ var S9BatchNodeScaleNoInsets = S9SpriteTestDemo.extend({
     ctor:function() {
         this._super();
 
-        var x = winSize.width / 6;
-        var y = 0 + (winSize.height / 6);
+        var x = winSize.width / 2;
+        var y = 0 + (winSize.height / 2);
 
         cc.log("S9BatchNodeScaleNoInsets ...");
 
@@ -202,7 +202,7 @@ var S9BatchNodeScaleNoInsets = S9SpriteTestDemo.extend({
 
         var blocks_scaled = cc.Scale9Sprite.create();
         cc.log("... created");
-        blocks_scaled.updateWithBatchNode(batchNode_scaled, cc.rect(0, 0, 96, 96), false, cc.rect(0, 0, 96, 96));
+        blocks_scaled.updateWithBatchNode(batchNode_scaled, cc.rect(0, 0, 96, 96), false);
         cc.log("... updateWithBatchNode");
 
         blocks_scaled.setPosition(cc.p(x, y));
@@ -227,8 +227,8 @@ var S9BatchNodeScaleNoInsetsSpriteSheet = S9SpriteTestDemo.extend({
     ctor:function() {
         this._super();
 
-        var x = winSize.width / 6;
-        var y = 0 + (winSize.height / 6);
+        var x = winSize.width / 2;
+        var y = 0 + (winSize.height / 2);
 
         cc.log("S9BatchNodeScaleNoInsetsSpriteSheet ...");
 
@@ -257,8 +257,8 @@ var S9BatchNodeScaleNoInsetsSpriteSheetRotated = S9SpriteTestDemo.extend({
     ctor:function() {
         this._super();
 
-        var x = winSize.width / 6;
-        var y = 0 + (winSize.height / 6);
+        var x = winSize.width / 2;
+        var y = 0 + (winSize.height / 2);
 
         cc.log("S9BatchNodeScaleNoInsetsSpriteSheetRotated ...");
 
@@ -288,8 +288,8 @@ var S9BatchNodeScaleWithCapInsets = S9SpriteTestDemo.extend({
     ctor:function() {
         this._super();
 
-        var x = winSize.width / 6;
-        var y = 0 + (winSize.height / 6);
+        var x = winSize.width / 2;
+        var y = 0 + (winSize.height / 2);
 
         cc.log("S9BatchNodeScaleWithCapInsets ...");
 
@@ -324,8 +324,8 @@ var S9BatchNodeScaleWithCapInsetsSpriteSheet = S9SpriteTestDemo.extend({
     ctor:function() {
         this._super();
 
-        var x = winSize.width / 6;
-        var y = 0 + (winSize.height / 6);
+        var x = winSize.width / 2;
+        var y = 0 + (winSize.height / 2);
 
         cc.log("S9BatchNodeScaleWithCapInsetsSpriteSheet ...");
 
@@ -354,8 +354,8 @@ var S9BatchNodeScaleWithCapInsetsSpriteSheetRotated = S9SpriteTestDemo.extend({
     ctor:function() {
         this._super();
 
-        var x = winSize.width / 6;
-        var y = 0 + (winSize.height / 6);
+        var x = winSize.width / 2;
+        var y = 0 + (winSize.height / 2);
 
         cc.log("S9BatchNodeScaleWithCapInsetsSpriteSheetRotated ...");
 

--- a/tests/SpriteTest/SpriteTest.js
+++ b/tests/SpriteTest/SpriteTest.js
@@ -3766,6 +3766,28 @@ var TextureColorCacheIssue2 = SpriteTestDemo.extend({
     }
 });
 
+var TextureColorRotated = SpriteTestDemo.extend({
+
+    _title:"Sub Sprite (rotated source)",
+    _subtitle:"createWithSpriteFrameName(); sub sprite",
+
+    ctor:function() {
+        this._super();
+
+        cc.SpriteFrameCache.getInstance().addSpriteFrames(s_s9s_blocks9_plist);
+
+        var block = cc.Sprite.createWithSpriteFrameName('blocks9r.png');
+
+        var x = winSize.width / 2;
+        var y = 0 + (winSize.height / 2);
+
+        block.setTextureRect(cc.rect(32, 32, 32, 32), true);
+
+        block.setPosition(cc.p(x, y));
+        this.addChild(block);
+    }
+});
+
 var SpriteTestScene = TestScene.extend({
     runThisTest:function () {
         sceneIdx = -1;
@@ -3838,7 +3860,8 @@ var arrayOfSpriteTest = [
     SpriteBatchBug1217,
     AnimationCacheFile,
     TextureColorCacheIssue,
-    TextureColorCacheIssue2
+    TextureColorCacheIssue2,
+    TextureColorRotated
 ];
 
 var nextSpriteTest = function () {

--- a/tests/SpriteTest/SpriteTest.js
+++ b/tests/SpriteTest/SpriteTest.js
@@ -3766,7 +3766,7 @@ var TextureColorCacheIssue2 = SpriteTestDemo.extend({
     }
 });
 
-var TextureColorRotated = SpriteTestDemo.extend({
+var TextureRotatedSpriteFrame = SpriteTestDemo.extend({
 
     _title:"Sub Sprite (rotated source)",
     _subtitle:"createWithSpriteFrameName(); sub sprite",
@@ -3861,7 +3861,7 @@ var arrayOfSpriteTest = [
     AnimationCacheFile,
     TextureColorCacheIssue,
     TextureColorCacheIssue2,
-    TextureColorRotated
+    TextureRotatedSpriteFrame
 ];
 
 var nextSpriteTest = function () {


### PR DESCRIPTION
This test uses the CCSprite from a rotated SpriteFrame where the TextureRect is set.
- This should show "center"
- But it shows "A"

This is fixed with [#747](https://github.com/cocos2d/cocos2d-html5/pull/747)
