### PR TITLE
add tests-boot-js-for-obfuscation.js as an entry

### DIFF
--- a/tests/PerformanceTest/PerformanceAnimationTest.js
+++ b/tests/PerformanceTest/PerformanceAnimationTest.js
@@ -74,7 +74,7 @@ var AnimationMenuLayer = PerformBasicLayer.extend({
     performTests:function () {
 
     }
-})
+});
 
 ////////////////////////////////////////////////////////
 //
@@ -158,7 +158,7 @@ var AnimationTest = AnimationMenuLayer.extend({
 
             this.lastRenderedCount = this.numNodes;
         }
-    },
+    }
 });
 
 var CharacterView = cc.Node.extend({
@@ -219,7 +219,7 @@ var CharacterView = cc.Node.extend({
 
     setDistance: function(){
         leftX = leftItem.getPositionX();
-    },
+    }
 });
 
 AnimationTest.scene = function () {

--- a/tests/tests-boot-jsb-for-obfuscation.js
+++ b/tests/tests-boot-jsb-for-obfuscation.js
@@ -1,0 +1,5 @@
+// JS Bindings constants
+var scene = cc.Scene.create();
+var layer = new TestController();
+scene.addChild(layer);
+director.runWithScene(scene);


### PR DESCRIPTION
1. Add tests-boot-js-for-obfuscation.js, 
   After obfuscation, all js files will be combined to one "game.js". So all "require" keywords should be removed, otherwise "can not find xxx.js" errors will raise.
2. Fixes  js grammars in PerformanceAnimationTest.js, which would lead google closure compiler to compilation failure.
