### PR TITLE
Adding a new test in LabelTest. Non-ascii UTF8 string from native should be converted to jsval correctly.

### DIFF
--- a/tests/LabelTest/LabelTest.js
+++ b/tests/LabelTest/LabelTest.js
@@ -874,8 +874,13 @@ var LabelTTFChinese = AtlasDemo.extend({
         this._super();
         var size = director.getWinSize();
         var label = cc.LabelTTF.create("中国", "Microsoft Yahei", 30);
-        label.setPosition(cc.p(size.width / 2, size.height / 2));
+        label.setPosition(cc.p(size.width / 2, size.height / 3 * 2));
         this.addChild(label);
+        
+        // Test UTF8 string from native to jsval.
+        var label2 = cc.LabelTTF.create("string from native:"+label.getString(), "Microsoft Yahei", 30);
+        label2.setPosition(cc.p(size.width / 2, size.height / 3));
+        this.addChild(label2);
     },
     title:function () {
         return "Testing cc.LabelTTF with Chinese character";


### PR DESCRIPTION
`LabelTest/LabelTTFChinese` can't work on cocos2d-iphone now. Nothing is shown in this test. I don't know why.
On Cocos2d-x jsb, it works ok now.
BTW, `cc.LabelTTF.string()` need to be `cc.LabelTTF.getString()`, `cc.LabelBMFont` as well.
So this Pull Request will break the JS Test in cocos2d-iphone jsb. 
Riq, could you please update cocos2d-iphone jsb to support this test?
