### PR TITLE
fixed #2082 remove ActionOrbit from arrayOfActionsTest when renderer is  Canvas

### DIFF
--- a/tests/ActionsTest/ActionsTest.js
+++ b/tests/ActionsTest/ActionsTest.js
@@ -2550,7 +2550,7 @@ var arrayOfActionsTest = [
     ActionCallFunc3,
     ActionReverseSequence,
     ActionReverseSequence2,
-    ActionOrbit,
+
     ActionFollow,
     ActionTargeted,
     ActionTargetedCopy,
@@ -2571,6 +2571,10 @@ var arrayOfActionsTest = [
     Issue1438,
     Issue1446
 ];
+
+if("opengl" in sys.capabilities){
+    arrayOfActionsTest.push(ActionOrbit);
+}
 
 var nextActionsTest = function () {
     actionsTestIdx++;


### PR DESCRIPTION
Remove ActionOrbit from arrayOfActionsTest when renderer is  Canvas
