### PR TITLE
Fix the single page version of cocos2d-js-tests til the point that PerformanceSpriteTest can be run.

### DIFF
--- a/tests/PerformanceTest/seedrandom.js
+++ b/tests/PerformanceTest/seedrandom.js
@@ -105,7 +105,7 @@
 // seedrandom()
 // This is the seedrandom function described above.
 //
-math['seedrandom'] = function seedrandom(seed, use_entropy) {
+math.seedrandom = function seedrandom(seed, use_entropy) {
   var key = [];
   var arc4;
 
@@ -126,7 +126,7 @@ math['seedrandom'] = function seedrandom(seed, use_entropy) {
   // This function returns a random double in [0, 1) that contains
   // randomness in every bit of the mantissa of the IEEE 754 value.
 
-  math['random'] = function random() {  // Closure to return a random double:
+  math.random = function random() {  // Closure to return a random double:
     var n = arc4.g(chunks);             // Start with a numerator n < 2 ^ 48
     var d = startdenom;                 //   and denominator d = 2 ^ 48.
     var x = 0;                          //   and no 'extra last byte'.

--- a/tests/build.xml
+++ b/tests/build.xml
@@ -68,8 +68,8 @@
 
     <target name="compile_test_advanced">
         <jscomp compilationLevel="advanced" warning="quiet"
-                debug="false" output="cocos2d-html5-testcases-advanced.js">
-            <warning group="internetExplorerChecks" level="OFF" />
+                debug="false" output="cocos2d-html5-testcases-advanced.js"
+                languageIn="ECMASCRIPT5">
             <externs dir="${basedir}/../../cocos2d">
                 <file name="cocos2d_externs.js"/>
             </externs>

--- a/tests/build.xml
+++ b/tests/build.xml
@@ -69,6 +69,7 @@
     <target name="compile_test_advanced">
         <jscomp compilationLevel="advanced" warning="quiet"
                 debug="false" output="cocos2d-html5-testcases-advanced.js">
+            <warning group="internetExplorerChecks" level="OFF" />
             <externs dir="${basedir}/../../cocos2d">
                 <file name="cocos2d_externs.js"/>
             </externs>
@@ -186,7 +187,6 @@
                 <file name="tileMap_parallax_nodes/CCTMXObjectGroup.js"/>
                 <file name="tileMap_parallax_nodes/CCTMXLayer.js"/>
                 <file name="tileMap_parallax_nodes/CCParallaxNode.js"/>
-                <file name="platform/jsloader.js"/>
             </sources>
             <sources dir="${basedir}/../../CocosDenshion">
                 <file name="SimpleAudioEngine.js"/>
@@ -226,6 +226,7 @@
                 <file name="chipmunk.js"/>
             </sources>
             <sources dir="${basedir}">
+                <file name="BaseTestLayer/BaseTestLayer.js"/>
                 <file name="tests-main.js"/>
                 <file name="tests_resources-html5.js"/>
                 <file name="TouchesTest/Ball.js"/>
@@ -242,27 +243,42 @@
                 <file name="ProgressActionsTest/ProgressActionsTest.js"/>
                 <file name="LayerTest/LayerTest.js"/>
                 <file name="SceneTest/SceneTest.js"/>
+                <file name="SpriteTest/SpriteTest.js"/>
                 <file name="TextureCacheTest/TextureCacheTest.js"/>
-                <file name="S9SpriteTest/S9SpriteTest.js"/>
                 <file name="CocosDenshionTest/CocosDenshionTest.js"/>
                 <file name="CocosNodeTest/CocosNodeTest.js"/>
                 <file name="RotateWorldTest/RotateWorldTest.js"/>
+                <file name="RenderTextureTest/RenderTextureTest.js"/>
                 <file name="IntervalTest/IntervalTest.js"/>
                 <file name="ActionManagerTest/ActionManagerTest.js"/>
                 <file name="EaseActionsTest/EaseActionsTest.js"/>
                 <file name="ParallaxTest/ParallaxTest.js"/>
                 <file name="PerformanceTest/PerformanceTest.js"/>
                 <file name="PerformanceTest/PerformanceSpriteTest.js"/>
+                <file name="PerformanceTest/PerformanceSpriteTest2.js"/>
                 <file name="PerformanceTest/PerformanceParticleTest.js"/>
                 <file name="PerformanceTest/PerformanceNodeChildrenTest.js"/>
                 <file name="PerformanceTest/PerformanceTextureTest.js"/>
+                <file name="PerformanceTest/PerformanceAnimationTest.js"/>
+                <file name="PerformanceTest/seedrandom.js"/>
                 <file name="FontTest/FontTest.js"/>
+                <file name="PerformanceTest/PerformanceTouchesTest.js"/>
+                <file name="LabelTest/LabelTest.js"/>
+                <file name="CurrentLanguageTest/CurrentLanguageTest.js"/>
+                <file name="TextInputTest/TextInputTest.js"/>
+                <file name="EventTest/EventTest.js"/>
+                <file name="UnitTest/UnitTest.js"/>
+                <file name="SysTest/SysTest.js"/>
+                <file name="EffectsTest/EffectsTest.js"/>
+                <file name="EffectsAdvancedTest/EffectsAdvancedTest.js"/>
+                <file name="MotionStreakTest/MotionStreakTest.js"/>
+                <file name="ClippingNodeTest/ClippingNodeTest.js"/>
+                <file name="OpenGLTest/OpenGLTest.js"/>
                 <file name="ExtensionsTest/ExtensionsTest.js"/>
                 <file name="ExtensionsTest/ControlExtensionTest/CCControlSceneManager.js"/>
                 <file name="ExtensionsTest/ControlExtensionTest/CCControlScene.js"/>
                 <file name="ExtensionsTest/ControlExtensionTest/CCControlButtonTest/CCControlButtonTest.js"/>
                 <file name="ExtensionsTest/TableViewTest/TableViewTestScene.js"/>
-                <file name="ExtensionsTest/EditBoxTest/EditBoxTest.js"/>
                 <file name="ExtensionsTest/CocosBuilderTest/CocosBuilderTest.js"/>
                 <file name="ExtensionsTest/CocosBuilderTest/TestHeader/TestHeaderLayer.js"/>
                 <file name="ExtensionsTest/CocosBuilderTest/HelloCocosBuilder/HelloCocosBuilderLayer.js"/>
@@ -273,14 +289,12 @@
                 <file name="ExtensionsTest/CocosBuilderTest/ParticleSystemTest/ParticleSystemTestLayer.js"/>
                 <file name="ExtensionsTest/CocosBuilderTest/ScrollViewTest/ScrollViewTestLayer.js"/>
                 <file name="ExtensionsTest/CocosBuilderTest/AnimationsTest/AnimationsTestLayer.js"/>
-                <file name="PerformanceTest/PerformanceTouchesTest.js"/>
-                <file name="LabelTest/LabelTest.js"/>
-                <file name="CurrentLanguageTest/CurrentLanguageTest.js"/>
-                <file name="TextInputTest/TextInputTest.js"/>
+                <file name="ExtensionsTest/CocosBuilderTest/TimelineCallbackTest/TimelineCallbackTestLayer.js"/>
+                <file name="ExtensionsTest/EditBoxTest/EditBoxTest.js"/>
+                <file name="ExtensionsTest/S9SpriteTest/S9SpriteTest.js"/>
+                <file name="ExtensionsTest/NetworkTest/WebSocketTest.js"/>
                 <file name="Box2dTest/Box2dTest.js"/>
                 <file name="ChipmunkTest/ChipmunkTest.js"/>
-                <file name="EventTest/EventTest.js"/>
-                <file name="UnitTest/UnitTest.js"/>
                 <file name="main.js"/>
             </sources>
         </jscomp>


### PR DESCRIPTION
This is accompanied by a [pull request](https://github.com/cocos2d/cocos2d-html5/pull/1004) to `cocos2d-html5`.

I don't claim to know much about the mechanism of the single page version (for example, I have no idea how you are supposed to use the `compile_test` target given that it doesn't include cocos2d. A pointer to the documentation is much appreciated!), but running `ant compile_test_advanced` very soon gave me

>    [jscomp] ERROR - Cannot read: /Users/kennyluck/Projects/cocos2d-html5/samples/tests/S9SpriteTest/S9SpriteTest.js
>    [jscomp] /Users/kennyluck/Projects/cocos2d-html5/samples/tests/tests_resources-html5.js:279: ERROR - Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option.

and this patch fixes this.

Also, this patch doesn't fix all tests (e.g. `PerformanceParticleTest` doesn't work), but I probably don't have time for this before I prepare the tests for our `CCClass.js` submission.

This change syncs the file list to `appFiles` in `tests-boot-html5.js`. Not sure this is the right thing to do.

(Increasing Closure Compiler's warning level seems like a fun thing to do too, but I'll leave that to the future.)
