### PR TITLE
Adding crystals.pvr.ccz --> crystals.pvr Published-Android/fileLookup.plist, TODO: CocosBuilder should publish fileLookup.plist correctly for android.

### DIFF
--- a/games/CrystalCraze/Published-Android/fileLookup.plist
+++ b/games/CrystalCraze/Published-Android/fileLookup.plist
@@ -32,6 +32,8 @@
 		<string>sounds/tap-3.ogg</string>
 		<key>sounds/timer.wav</key>
 		<string>sounds/timer.ogg</string>
+		<key>crystals.pvr.ccz</key>
+		<string>crystals.pvr</string>
 	</dict>
 	<key>metadata</key>
 	<dict>


### PR DESCRIPTION
...
