### PR TITLE
fixed #2468 modify code to call public function "addTargetWithActionForControlEvents" of cc.ControlButton instead to protected function "_addTargetWithActionForControlEvent"

### DIFF
--- a/tests/ExtensionsTest/ControlExtensionTest/CCControlButtonTest/CCControlButtonTest.js
+++ b/tests/ExtensionsTest/ControlExtensionTest/CCControlButtonTest/CCControlButtonTest.js
@@ -141,14 +141,14 @@ var ControlButtonTest_Event = ControlScene.extend({
             this.addChild(background);
 
             // Sets up event handlers
-            controlButton.addTargetWithActionForControlEvent(this, this.touchDownAction, cc.CONTROL_EVENT_TOUCH_DOWN);
-            controlButton.addTargetWithActionForControlEvent(this, this.touchDragInsideAction, cc.CONTROL_EVENT_TOUCH_DRAG_INSIDE);
-            controlButton.addTargetWithActionForControlEvent(this, this.touchDragOutsideAction, cc.CONTROL_EVENT_TOUCH_DRAG_OUTSIDE);
-            controlButton.addTargetWithActionForControlEvent(this, this.touchDragEnterAction, cc.CONTROL_EVENT_TOUCH_DRAG_ENTER);
-            controlButton.addTargetWithActionForControlEvent(this, this.touchDragExitAction, cc.CONTROL_EVENT_TOUCH_DRAG_EXIT);
-            controlButton.addTargetWithActionForControlEvent(this, this.touchUpInsideAction, cc.CONTROL_EVENT_TOUCH_UP_INSIDE);
-            controlButton.addTargetWithActionForControlEvent(this, this.touchUpOutsideAction, cc.CONTROL_EVENT_TOUCH_UP_OUTSIDE);
-            controlButton.addTargetWithActionForControlEvent(this, this.touchCancelAction, cc.CONTROL_EVENT_TOUCH_CANCEL);
+            controlButton.addTargetWithActionForControlEvents(this, this.touchDownAction, cc.CONTROL_EVENT_TOUCH_DOWN);
+            controlButton.addTargetWithActionForControlEvents(this, this.touchDragInsideAction, cc.CONTROL_EVENT_TOUCH_DRAG_INSIDE);
+            controlButton.addTargetWithActionForControlEvents(this, this.touchDragOutsideAction, cc.CONTROL_EVENT_TOUCH_DRAG_OUTSIDE);
+            controlButton.addTargetWithActionForControlEvents(this, this.touchDragEnterAction, cc.CONTROL_EVENT_TOUCH_DRAG_ENTER);
+            controlButton.addTargetWithActionForControlEvents(this, this.touchDragExitAction, cc.CONTROL_EVENT_TOUCH_DRAG_EXIT);
+            controlButton.addTargetWithActionForControlEvents(this, this.touchUpInsideAction, cc.CONTROL_EVENT_TOUCH_UP_INSIDE);
+            controlButton.addTargetWithActionForControlEvents(this, this.touchUpOutsideAction, cc.CONTROL_EVENT_TOUCH_UP_OUTSIDE);
+            controlButton.addTargetWithActionForControlEvents(this, this.touchCancelAction, cc.CONTROL_EVENT_TOUCH_CANCEL);
             return true;
         }
         return false;


### PR DESCRIPTION
Modify code to call public function "addTargetWithActionForControlEvents" of cc.ControlButton instead to protected function "_addTargetWithActionForControlEvent"
