### PR TITLE
Closed #2844: Rename version 2.1.6 of Cocos2d-html5 to 2.2

### DIFF
--- a/tests/tests-boot-html5.js
+++ b/tests/tests-boot-html5.js
@@ -36,7 +36,7 @@
         renderMode:0,       //Choose of RenderMode: 0(default), 1(Canvas only), 2(WebGL only)
         tag:'gameCanvas', //the dom element to run cocos2d on
         engineDir:'../../cocos2d/',
-        //SingleEngineFile:'../../lib/Cocos2d-html5-v2.1.6.min.js',
+        //SingleEngineFile:'../../lib/Cocos2d-html5-v2.2.min.js',
         appFiles:[//'src/AppDelegate.js',
 
             // base class


### PR DESCRIPTION
Rename version 2.1.6 of Cocos2d-html5 to 2.2
