### PR TITLE
unit tests for issue 3065

### DIFF
--- a/tests/UnitTest/UnitTest.js
+++ b/tests/UnitTest/UnitTest.js
@@ -162,8 +162,14 @@ var RectUnitTest = UnitTestBase.extend({
         var node = cc.Node.create();
         node.setContentSize( cc.size(99,101) );
         var bb = node.getBoundingBox();
-        if( bb.height != 101 || bb.width != 99)
-            throw "Fail getBoundingBox()";
+        if (!bb.size)
+            throw "Fail getBoundingBox().size";
+        if (!bb.origin)
+            throw "Fail getBoundingBox().origin";
+        if( bb.size.height != 101 || bb.size.width != 99)
+            throw "Fail getBoundingBox().size values";
+        if (bb.origin.x != node.getPositionX() || bb.origin.y != node.getPositionY())
+            throw "Fail getBoundingBox().origin values";
         ret.push( bb.height );
         ret.push( bb.width );
         return ret;


### PR DESCRIPTION
When using javascript through jsb, a call to getBoundingBox() returns an object with properties x/y/height/width and not origin/size properties.
Submitted as issue [3065](http://www.cocos2d-x.org/issues/3065)
cocos2d-x pull request [4010](https://github.com/cocos2d/cocos2d-x/pull/4010)
